### PR TITLE
Hicpro files

### DIFF
--- a/docs/content/Usage.md
+++ b/docs/content/Usage.md
@@ -87,22 +87,22 @@ SRR3467175  SRR3467176  SRR3467177  SRR3467178
 ./hicpro/hic_results/data/SRR3467175:
 SRR3467175_hg19.bwt2pairs.DEPairs*    SRR3467175_hg19.bwt2pairs.RSstat*   SRR3467175_hg19.bwt2pairs.SinglePairs*
 SRR3467175_hg19.bwt2pairs.DumpPairs*  SRR3467175_hg19.bwt2pairs.SCPairs*  SRR3467175_hg19.bwt2pairs.validPairs*
-SRR3467175_allValidPairs*
+SRR3467175.allValidPairs*
 
 ./hicpro/hic_results/data/SRR3467176:
 SRR3467176_hg19.bwt2pairs.DEPairs*    SRR3467176_hg19.bwt2pairs.RSstat*   SRR3467176_hg19.bwt2pairs.SinglePairs*
 SRR3467176_hg19.bwt2pairs.DumpPairs*  SRR3467176_hg19.bwt2pairs.SCPairs*  SRR3467176_hg19.bwt2pairs.validPairs*
-SRR3467176_allValidPairs*
+SRR3467176.allValidPairs*
 
 ./hicpro/hic_results/data/SRR3467177:
 SRR3467177_hg19.bwt2pairs.DEPairs*    SRR3467177_hg19.bwt2pairs.RSstat*   SRR3467177_hg19.bwt2pairs.SinglePairs*
 SRR3467177_hg19.bwt2pairs.DumpPairs*  SRR3467177_hg19.bwt2pairs.SCPairs*  SRR3467177_hg19.bwt2pairs.validPairs*
-SRR3467177_allValidPairs*
+SRR3467177.allValidPairs*
 
 ./hicpro/hic_results/data/SRR3467178:
 SRR3467178_hg19.bwt2pairs.DEPairs*    SRR3467178_hg19.bwt2pairs.RSstat*   SRR3467178_hg19.bwt2pairs.SinglePairs*
 SRR3467178_hg19.bwt2pairs.DumpPairs*  SRR3467178_hg19.bwt2pairs.SCPairs*  SRR3467178_hg19.bwt2pairs.validPairs*
-SRR3467178_allValidPairs*
+SRR3467178.allValidPairs*
 
 ...
 
@@ -140,19 +140,19 @@ hicpro/
 |  |  |-- SRR3467175
 |  |  |  |-- SRR3467175*RSstat
 |  |  |  |-- SRR3467175*Pairs # 5 Files
-|  |  |  |-- SRR3467175_allValidPairs
+|  |  |  |-- SRR3467175.allValidPairs
 |  |  |-- SRR3467176
 |  |  |  |-- SRR3467176*RSstat
 |  |  |  |-- SRR3467176*Pairs # 5 Files
-|  |  |  |-- SRR3467175_allValidPairs
+|  |  |  |-- SRR3467175.allValidPairs
 |  |  |-- SRR3467177
 |  |  |  |-- SRR3467177*RSstat
 |  |  |  |-- SRR3467177*Pairs # 5 Files
-|  |  |  |-- SRR3467175_allValidPairs
+|  |  |  |-- SRR3467175.allValidPairs
 |  |  |-- SRR3467178
 |  |  |  |-- SRR3467178*RSstat
 |  |  |  |-- SRR3467178*Pairs # 5 Files
-|  |  |  |-- SRR3467175_allValidPairs
+|  |  |  |-- SRR3467175.allValidPairs
 GM12878_SMC3_ChIPSeq.narrowPeak
 hg19_MboI_resfrag.bed.gz
 yaml/

--- a/hichipper/hichipperHelp.py
+++ b/hichipper/hichipperHelp.py
@@ -229,7 +229,7 @@ def verify_sample_hichipper_old(sample, boo, hicprooutput):
 	hc1 = glob.glob(hicprooutput + '/hic_results/data/' + sample + '/*.RSstat')
 	hc2 = glob.glob(hicprooutput + '/hic_results/data/' + sample + '/*.*Pairs')
 	hc2 = [a for a in hc2 if re.search("DEPairs|SCPairs|validPairs|SinglePairs|DumpPairs",a) is not None]
-	hc3 = glob.glob(hicprooutput + '/hic_results/data/' + sample + '/*_allValidPairs')
+	hc3 = glob.glob(hicprooutput + '/hic_results/data/' + sample + '/*[_,.]allValidPairs')
 	
 	if(boo):
 		return((len(bt) > 0) and (len(hc1) > 0) and (len(hc2) % 5) == 0 and (len(hc3) > 0))

--- a/hichipper/hichipperHelp.py
+++ b/hichipper/hichipperHelp.py
@@ -1,3 +1,4 @@
+import glob
 import itertools
 import time
 from whichcraft import which
@@ -224,11 +225,11 @@ def available_cpu_count():
 
 # Make sure that files are present
 def verify_sample_hichipper_old(sample, boo, hicprooutput):
-	bt = os.popen('ls ' + hicprooutput + '/bowtie_results/bwt2/' + sample + "/*.pairstat").read().strip().split("\n")
-	hc1 = os.popen('ls ' + hicprooutput + '/hic_results/data/' + sample + "/*.RSstat").read().strip().split("\n")
-	hc2 = os.popen('ls ' + hicprooutput + '/hic_results/data/' + sample + "/*.*Pairs").read().strip().split("\n")
+	bt = glob.glob(hicprooutput + '/bowtie_results/bwt2/' + sample + '/*.pairstat')
+	hc1 = glob.glob(hicprooutput + '/hic_results/data/' + sample + '/*.RSstat')
+	hc2 = glob.glob(hicprooutput + '/hic_results/data/' + sample + '/*.*Pairs')
 	hc2 = [a for a in hc2 if re.search("DEPairs|SCPairs|validPairs|SinglePairs|DumpPairs",a) is not None]
-	hc3 = os.popen('ls ' + hicprooutput + '/hic_results/data/' + sample + "/*_allValidPairs").read().strip().split("\n")
+	hc3 = glob.glob(hicprooutput + '/hic_results/data/' + sample + '/*_allValidPairs')
 	
 	if(boo):
 		return((len(bt) > 0) and (len(hc1) > 0) and (len(hc2) % 5) == 0 and (len(hc3) > 0))

--- a/hichipper/interactionsCall.sh
+++ b/hichipper/interactionsCall.sh
@@ -21,7 +21,7 @@ Total_PETs=`head -1 "${HICPRO_OUT}/bowtie_results/bwt2/${SAMPLE}/"*pairstat | aw
 echo "`date`: Total_PETs=${Total_PETs}" | tee -a $LOG_FILE
 Mapped_unique_quality_pairs=`cat "${HICPRO_OUT}/hic_results/data/${SAMPLE}/"*Pairs | wc -l | awk '{print $1}'`
 echo "`date`: Mapped_unique_quality_pairs=${Mapped_unique_quality_pairs}" | tee -a $LOG_FILE
-Mapped_unique_quality_valid_pairs=`cat "${HICPRO_OUT}/hic_results/data/${SAMPLE}/"*_allValidPairs | wc -l | awk '{print $1}'`
+Mapped_unique_quality_valid_pairs=`cat "${HICPRO_OUT}/hic_results/data/${SAMPLE}/"*[_,.]allValidPairs | wc -l | awk '{print $1}'`
 echo "`date`: Mapped_unique_quality_valid_pairs=${Mapped_unique_quality_valid_pairs}"| tee -a $LOG_FILE
 
 # Merge gaps; check bedtools
@@ -40,7 +40,7 @@ fi
 # Count reads in anchors; spit out only valid pairs sorted and pretty
 cat "${HICPRO_OUT}/hic_results/data/${SAMPLE}/"*Pairs | awk -v RL="$HALF_LEN" '{print $2 "\t" $3 - RL "\t" $3 + RL}' | awk '$2 > 0 {print $0}' | coverageBed -a stdin -b "${WK_DIR}/${OUT_NAME}/${SAMPLE}_temporary_peaks.merged.bed.tmp" -counts | awk '{sum += $4} END {print sum}' > "${WK_DIR}/${OUT_NAME}/${SAMPLE}.peakReads.tmp"
 cat "${HICPRO_OUT}/hic_results/data/${SAMPLE}/"*Pairs | awk -v RL="$HALF_LEN" '{print $5 "\t" $6 - RL "\t" $6 + RL}' | awk '$2 > 0 {print $0}' | coverageBed -a stdin -b "${WK_DIR}/${OUT_NAME}/${SAMPLE}_temporary_peaks.merged.bed.tmp" -counts | awk '{sum += $4} END {print sum}' >> "${WK_DIR}/${OUT_NAME}/${SAMPLE}.peakReads.tmp"
-cat "${HICPRO_OUT}/hic_results/data/${SAMPLE}/"*_allValidPairs | awk -v RL="$HALF_LEN" '{if ($2<$5 || ($2==$5 && $3<=$6)) print $2,$3-RL,$3+RL,$5,$6-RL,$6+RL; else print $5,$6-RL,$6+RL,$2,$3-RL,$3+RL}' 'OFS=\t' | awk '$2 > 0 && $5 > 0 {print $0}' | sort -k1,1n -k2,2n -k4,4n -k5,5n > "${WK_DIR}/${OUT_NAME}/${SAMPLE}_interactions.bedpe.tmp"
+cat "${HICPRO_OUT}/hic_results/data/${SAMPLE}/"*[_,.]allValidPairs | awk -v RL="$HALF_LEN" '{if ($2<$5 || ($2==$5 && $3<=$6)) print $2,$3-RL,$3+RL,$5,$6-RL,$6+RL; else print $5,$6-RL,$6+RL,$2,$3-RL,$3+RL}' 'OFS=\t' | awk '$2 > 0 && $5 > 0 {print $0}' | sort -k1,1n -k2,2n -k4,4n -k5,5n > "${WK_DIR}/${OUT_NAME}/${SAMPLE}_interactions.bedpe.tmp"
 READS_IN_ANCHORS=`awk '{sum += $1} END {print sum}' "${WK_DIR}/${OUT_NAME}/${SAMPLE}.peakReads.tmp" | awk '{print $1}'`
 
 # Valid interaction statistics

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,7 +14,7 @@ and testing the output against something we think is correct
 
 ```
 hichipper call --out outputCallBAM --restriction-frags ../RestrictionFragmentFiles/hg19_MboI_resfrag.bed.gz --peaks chipseq/GM12878_SMC3_ChIPSeq_chr22.narrowPeak --skip-resfrag-pad --basic-qc --skip-diffloop --input-bam call_inputs/HiCUP_chr22.bam
-hichipper call --out outputCallvi --restriction-frags ../RestrictionFragmentFiles/hg19_MboI_resfrag.bed.gz --peaks chipseq/GM12878_SMC3_ChIPSeq_chr22.narrowPeak --skip-resfrag-pad --basic-qc --skip-diffloop --input-bam call_inputs/dSRR3467177_allValidPairs 
+hichipper call --out outputCallvi --restriction-frags ../RestrictionFragmentFiles/hg19_MboI_resfrag.bed.gz --peaks chipseq/GM12878_SMC3_ChIPSeq_chr22.narrowPeak --skip-resfrag-pad --basic-qc --skip-diffloop --input-bam call_inputs/dSRR3467177.allValidPairs 
 
 ```
 

--- a/tests/verifyHCP.py
+++ b/tests/verifyHCP.py
@@ -20,7 +20,7 @@ bt = glob.glob(hicprooutput + '/bowtie_results/bwt2/' + sample + '/*.pairstat')
 hc1 = glob.glob(hicprooutput + '/hic_results/data/' + sample + '/*.RSstat')
 hc2 = glob.glob(hicprooutput + '/hic_results/data/' + sample + '/*.*Pairs')
 hc2 = [a for a in hc2 if re.search("DEPairs|SCPairs|validPairs|SinglePairs|DumpPairs",a) is not None]
-hc3 = glob.glob(hicprooutput + '/hic_results/data/' + sample + '/*_allValidPairs')
+hc3 = glob.glob(hicprooutput + '/hic_results/data/' + sample + '/*[_,.]allValidPairs')
 
 print(bt)
 print(hc1)

--- a/tests/verifyHCP.py
+++ b/tests/verifyHCP.py
@@ -1,3 +1,4 @@
+import glob
 import sys
 import re
 import os
@@ -15,11 +16,11 @@ options, arguments = opts.parse_args()
 hicprooutput = options.hicpro
 sample = options.sample
 
-bt = os.popen('ls ' + hicprooutput + '/bowtie_results/bwt2/' + sample + "/*.pairstat").read().strip().split("\n")
-hc1 = os.popen('ls ' + hicprooutput + '/hic_results/data/' + sample + "/*.RSstat").read().strip().split("\n")
-hc2 = os.popen('ls ' + hicprooutput + '/hic_results/data/' + sample + "/*.*Pairs").read().strip().split("\n")
+bt = glob.glob(hicprooutput + '/bowtie_results/bwt2/' + sample + '/*.pairstat')
+hc1 = glob.glob(hicprooutput + '/hic_results/data/' + sample + '/*.RSstat')
+hc2 = glob.glob(hicprooutput + '/hic_results/data/' + sample + '/*.*Pairs')
 hc2 = [a for a in hc2 if re.search("DEPairs|SCPairs|validPairs|SinglePairs|DumpPairs",a) is not None]
-hc3 = os.popen('ls ' + hicprooutput + '/hic_results/data/' + sample + "/*_allValidPairs").read().strip().split("\n")
+hc3 = glob.glob(hicprooutput + '/hic_results/data/' + sample + '/*_allValidPairs')
 
 print(bt)
 print(hc1)


### PR DESCRIPTION
From the [HiC-Pro 2.11.0 changelog](https://github.com/nservant/HiC-Pro/blob/master/CHANGELOG):
> SIGNIFICANT USER-VISIBLE CHANGES
>
> ...
>   o _allValidPairs extension is now changed to .allValidpairs

This PR supports finding files named according to both the old and new patterns.