### PR TITLE
Restriction fragment aware background correction fix

### DIFF
--- a/hichipper/lambdaProcess.R
+++ b/hichipper/lambdaProcess.R
@@ -8,10 +8,14 @@ suppressMessages(suppressWarnings(library(data.table)))
 suppressMessages(suppressWarnings(library(reshape2)))
 
 args <- commandArgs(trailingOnly = TRUE)
-resfile <- args[1]
-treatmentfile <- args[2]
-backgroundfile <- args[3]
-outdir <- args[4]
+# resfile <- args[1]
+# treatmentfile <- args[2]
+# backgroundfile <- args[3]
+# outdir <- args[4]
+resfile <- "hichipper/MboI_resfrag_hg38.bed"
+treatmentfile <- "hichipper/22RV1_REP1_temporary_treat_pileup.bdg"
+backgroundfile <- "hichipper/22RV1_REP1_temporary_control_lambda.bdg"
+outdir <- "hichipper"
 K <- 1000000 # Number of loci to sample from 
 
 # Import Restriction Fragments / Convert to GRanges
@@ -65,8 +69,12 @@ computeRatioEtc <- function(treatmentfile, backgroundfile){
   # Compute nearest neighbor for background
   mid <- (start(cont) + end(cont))/2
   backmid <- as(data.frame(chrom=seqnames(cont), start=mid, end=mid), "GRanges")
-  mcols(cont)$dist <- mcols(distanceToNearest(backmid, resSites))[,1]
-  
+  nearestHits <- distanceToNearest(backmid, resSites)
+  nearestDist <- rep(NA, length(cont))
+  nearestDist[queryHits(nearestHits)] <- mcols(nearestHits)$distance
+  nearestDist[is.na(nearestDist)] <- 0
+  mcols(cont)$dist <- nearestDist
+
   vals <- tapply(txtVals/contVals, nndist, mean)
   
   # Write adjusted treatment (only filters out regions where no restriction enzyme information is contained)

--- a/hichipper/lambdaProcess.R
+++ b/hichipper/lambdaProcess.R
@@ -8,14 +8,10 @@ suppressMessages(suppressWarnings(library(data.table)))
 suppressMessages(suppressWarnings(library(reshape2)))
 
 args <- commandArgs(trailingOnly = TRUE)
-# resfile <- args[1]
-# treatmentfile <- args[2]
-# backgroundfile <- args[3]
-# outdir <- args[4]
-resfile <- "hichipper/MboI_resfrag_hg38.bed"
-treatmentfile <- "hichipper/22RV1_REP1_temporary_treat_pileup.bdg"
-backgroundfile <- "hichipper/22RV1_REP1_temporary_control_lambda.bdg"
-outdir <- "hichipper"
+resfile <- args[1]
+treatmentfile <- args[2]
+backgroundfile <- args[3]
+outdir <- args[4]
 K <- 1000000 # Number of loci to sample from 
 
 # Import Restriction Fragments / Convert to GRanges


### PR DESCRIPTION
When using restriction fragment aware background correction, hichipper would often fail with this error:

```
Fri Feb  7 11:05:51 PST 2025: Something went wrong in determining peaks for anchor inference; rerun with the  flag to debug.
```

When assigning mcols(cont)$dist in the lamdaProcess.R file, it is possible that the number of rows returned from distanceToNearest() do not match the number of rows in cont. 

This solution assigns the missing rows as NA and then fills the distance with a zero.

```
> nearestHits
Hits object with 48306420 hits and 1 metadata column:
             queryHits subjectHits |  distance
             <integer>   <integer> | <integer>
         [1]         1     7200235 |       520
         [2]         3     7200494 |       276
         [3]         4     7181959 |       661
         [4]         5     7181973 |       364
         [5]         6     7181973 |       361
         ...       ...         ... .       ...
  [48306416]  48306419     3655739 |         1
  [48306417]  48306420     3655740 |         2
  [48306418]  48306421     3655740 |         6
  [48306419]  48306422     3655761 |       367
  [48306420]  48306423     7195795 |       382
  -------
  queryLength: 48306423 / subjectLength: 7499821

> cont
GRanges object with 48306423 ranges and 2 metadata columns:
                           seqnames              ranges strand |        V4      dist
                              <Rle>           <IRanges>  <Rle> | <numeric> <integer>
         [1]       chrUn_KI270748v1             0-92286      * |   5.44588       520
         [2]       chrUn_KI270337v1               0-331      * |   5.44588      <NA>
         [3]       chrUn_KI270749v1            0-158273      * |   5.44588       276
         [4] chr1_KI270713v1_random             0-14438      * |   5.44588       661
         [5] chr1_KI270713v1_random         14438-14439      * |   5.46840       364
         ...                    ...                 ...    ... .       ...       ...
  [48306419]                   chr8 145065626-145065644      * |   5.49780         1
  [48306420]                   chr8 145065644-145065650      * |   5.46840         2
  [48306421]                   chr8 145065650-145065665      * |   5.45370         6
  [48306422]                   chr8 145065665-145078500      * |   5.44588       367
  [48306423]       chrUn_KI270465v1              0-1143      * |   5.44588       382
  -------
```